### PR TITLE
Create LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,1 @@
+[LICENSE.md](https://github.com/carsonpurnell/cryotomosim_CTS/files/11365738/LICENSE.md)


### PR DESCRIPTION
Providing your license as a markdown file lets people see the text on GitHub without needing to download a Word doc.